### PR TITLE
Update cookies with their newly named values

### DIFF
--- a/default.config.js
+++ b/default.config.js
@@ -35,8 +35,8 @@ module.exports = {
 					cookie: {
 						// If there's and extra space at the end of the cookie value, please remove it
 						// e.g. "token: "testxdxd123    " -> "token: "testxdxd123"
-						token: "", // cookie_token_v2
-						mid: "", // account_mid_v2
+						token: "", // ltoken_v2
+						mid: "", // ltmid_v2
 						ltuid: "" // ltuid_v2
 					}
 				}
@@ -51,8 +51,8 @@ module.exports = {
 					cookie: {
 						// If there's and extra space at the end of the cookie value, please remove it
 						// e.g. "token: "testxdxd123    " -> "token: "testxdxd123"
-						token: "", // cookie_token_v2
-						mid: "", // account_mid_v2
+						token: "", // ltoken_v2
+						mid: "", // ltmid_v2
 						ltuid: "", // ltuid_v2
 						// Not required, but you can add it to hopefully avoid captcha if you have multiple accounts
 						deviceId: "",
@@ -92,8 +92,8 @@ module.exports = {
 					cookie: {
 						// If there's and extra space at the end of the cookie value, please remove it
 						// e.g. "token: "testxdxd123    " -> "token: "testxdxd123"
-						token: "", // cookie_token_v2
-						mid: "", // account_mid_v2
+						token: "", // ltoken_v2
+						mid: "", // ltmid_v2
 						ltuid: "", // ltuid_v2
 						// Not required, but you can add it to hopefully avoid captcha if you have multiple accounts
 						deviceId: "",
@@ -116,8 +116,8 @@ module.exports = {
 				// Delete this if you only have one account
 				{
 					cookie: {
-						token: "", // cookie_token_v2
-						mid: "", // account_mid_v2
+						token: "", // ltoken_v2
+						mid: "", // ltmid_v2
 						ltuid: "", // ltuid_v2
 						deviceId: "",
 						deviceFp: ""

--- a/get-cookie.js
+++ b/get-cookie.js
@@ -11,8 +11,8 @@ const stuff = cookies.map(cookie => {
 			.map(cookieItem => cookieItem.split("=").map(part => part.trim()))
 	);
 	return {
-		token: cookieObj.cookie_token_v2,
-		mid: cookieObj.account_mid_v2,
+		token: cookieObj.ltoken_v2,
+		mid: cookieObj.ltmid_v2,
 		ltuid: cookieObj.account_id_v2
 	};
 });

--- a/hoyolab-modules/genshin.js
+++ b/hoyolab-modules/genshin.js
@@ -42,7 +42,7 @@ module.exports = class Genshin extends require("./template.js") {
 
 	async login () {
 		const accounts = this.data;
-        
+
 		for (const account of accounts) {
 			const { token, mid, ltuid } = account.cookie;
 			if (!token || !mid || !ltuid) {
@@ -54,7 +54,7 @@ module.exports = class Genshin extends require("./template.js") {
 				});
 			}
 
-			const cookieData = `cookie_token_v2=${token}; account_mid_v2=${mid}; account_id_v2=${ltuid}`;
+			const cookieData = `ltoken_v2=${token}; ltmid_v2=${mid}; account_id_v2=${ltuid}`;
 
 			const { body, statusCode } = await app.Got("MiHoYo", {
 				url: "https://bbs-api-os.hoyolab.com/game_record/card/wapi/getGameRecordCard",
@@ -77,7 +77,7 @@ module.exports = class Genshin extends require("./template.js") {
 					}
 				});
 			}
-            
+
 			const res = body;
 			if (res.retcode !== 0) {
 				throw new app.Error({
@@ -482,7 +482,7 @@ module.exports = class Genshin extends require("./template.js") {
 		}
 
 		const data = res.body.data;
-		
+
 		const stamina = {
 			currentStamina: data.current_resin,
 			maxStamina: data.max_resin,

--- a/hoyolab-modules/honkai.js
+++ b/hoyolab-modules/honkai.js
@@ -37,7 +37,7 @@ module.exports = class HonkaiImpact extends require("./template.js") {
 
 	async login () {
 		const accounts = this.data;
-        
+
 		for (const account of accounts) {
 			const { token, mid, ltuid } = account.cookie;
 			if (!token || !mid || !ltuid) {
@@ -49,7 +49,7 @@ module.exports = class HonkaiImpact extends require("./template.js") {
 				});
 			}
 
-			const cookieData = `cookie_token_v2=${token}; account_mid_v2=${mid}; account_id_v2=${ltuid}`;
+			const cookieData = `ltoken_v2=${token}; ltmid_v2=${mid}; account_id_v2=${ltuid}`;
 
 			const { body, statusCode } = await app.Got("MiHoYo", {
 				url: "https://bbs-api-os.hoyolab.com/game_record/card/wapi/getGameRecordCard",
@@ -72,7 +72,7 @@ module.exports = class HonkaiImpact extends require("./template.js") {
 					}
 				});
 			}
-            
+
 			const res = body;
 			if (res.retcode !== 0) {
 				throw new app.Error({

--- a/hoyolab-modules/starrail.js
+++ b/hoyolab-modules/starrail.js
@@ -27,7 +27,7 @@ module.exports = class StarRail extends require("./template.js") {
 			gameId: 6,
 			config: DEFAULT_CONSTANTS
 		});
-        
+
 		if (!this.id) {
 			throw new app.Error({
 				message: "No HoyoLab ID provided for StarRail controller"
@@ -54,7 +54,7 @@ module.exports = class StarRail extends require("./template.js") {
 				});
 			}
 
-			const cookieData = `cookie_token_v2=${token}; account_mid_v2=${mid}; account_id_v2=${ltuid}`;
+			const cookieData = `ltoken_v2=${token}; ltmid_v2=${mid}; account_id_v2=${ltuid}`;
 
 			const { body, statusCode } = await app.Got("MiHoYo", {
 				url: "https://bbs-api-os.hoyolab.com/game_record/card/wapi/getGameRecordCard",
@@ -77,7 +77,7 @@ module.exports = class StarRail extends require("./template.js") {
 					}
 				});
 			}
-            
+
 			const res = body;
 			if (res.retcode !== 0) {
 				throw new app.Error({

--- a/hoyolab-modules/zenless.js
+++ b/hoyolab-modules/zenless.js
@@ -51,7 +51,7 @@ module.exports = class ZenlessZoneZero extends require("./template.js") {
 				});
 			}
 
-			const cookieData = `cookie_token_v2=${token}; account_mid_v2=${mid}; account_id_v2=${ltuid}`;
+			const cookieData = `ltoken_v2=${token}; ltmid_v2=${mid}; account_id_v2=${ltuid}`;
 
 			const { body, statusCode } = await app.Got("MiHoYo", {
 				url: "https://bbs-api-os.hoyolab.com/game_record/card/wapi/getGameRecordCard",
@@ -74,7 +74,7 @@ module.exports = class ZenlessZoneZero extends require("./template.js") {
 					}
 				});
 			}
-            
+
 			const res = body;
 			if (res.retcode !== 0) {
 				throw new app.Error({


### PR DESCRIPTION
I noticed this while trying to log in. The cookie stored in my local storage was different from the one referenced within the configuration. I ignored this initially and just put the values that I thought each value in the configuration was referencing:
```
ltmid_v2 -> account_mid_v2
ltoken_v2 -> cookie_token_v2
```

This didn't work and gave me a "Please login" error message:
```json
{"retcode":10001,"message":"Please login","res":{"data":null,"message":"Please login","retcode":10001}}
```

Eventually, I figured out that this might be related to what I ignored earlier, and after changing the values to represent the ones I saw in my local storage, the login worked without issues.