### PR TITLE
Remove usage of default config, seperate file not found/parsing error output

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,13 +20,11 @@ let config;
 try {
 	config = JSON5.parse(file.readFileSync("./config.json5"));
 }
-catch {
-	try {
-		config = JSON5.parse(file.readFileSync("./default.config.json5"));
+catch (e) {
+	if (file.existsSync("./config.json5") === false) {
+		throw new Error({ message: "No config file (config.json5) was found. Please follow the setup instructions on https://github.com/torikushiii/hoyolab-auto?tab=readme-ov-file#installation \n" + e });
 	}
-	catch (e) {
-		throw new Error({ message: "No default or custom configuration found." });
-	}
+	throw new Error({ message: "An error occurred when reading your configuration file. Please check and fix the following error:\n" + e });
 }
 
 (async () => {


### PR DESCRIPTION
Since the user should never be modifying default.config.json5 _anyway_, this removes the check/usage of that and instead points the user to the install/setup portion of the repo if it can't find the user config. Additionally, if it's a parsing error (or any other error) rather than file not found, it will output that error instead.

Previous behavior would say it couldn't find the file if it failed to parse it (or any other error).

example output:
```
D:\hoyolab-auto\index.js:27
        throw new Error({ message: "An error occurred when reading your configuration file. Please check and fix the following error:\n" + e });
        ^

Error: An error occurred when reading your configuration file. Please check and fix the following error:
SyntaxError: JSON5: invalid character 'c' at 28:21
    at Object.<anonymous> (D:\hoyolab-auto\index.js:27:8)
    at Module._compile (node:internal/modules/cjs/loader:1469:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Module._load (node:internal/modules/cjs/loader:1104:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:174:12)
    at node:internal/main/run_main_module:28:49 {
  [cause]: undefined
}
```