### PR TITLE
[Fix] Use google app scripts sleep

### DIFF
--- a/services/google-script/index.js
+++ b/services/google-script/index.js
@@ -388,7 +388,7 @@ class Game {
 			}
 
 			await this.redeemCode(account, code.code);
-			await this.delay(6000);
+			Utilities.sleep(6000);
 
 			this.saveRedeemedCode(code.code);
 		}


### PR DESCRIPTION
Google app scripts doesn't care about javascript delay. We use the specific app scripts sleep function to instead properly wait.