### PR TITLE
Build docker image additionally for ARM platform

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -8,21 +8,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
         username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
-
     - name: Build and push Docker image
       uses: docker/build-push-action@v2
       with:

--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -28,4 +28,5 @@ jobs:
       with:
         context: .
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ghcr.io/${{ secrets.GHCR_USERNAME }}/hoyolab-auto:latest


### PR DESCRIPTION
I have simply modified the Github action to also build a second image for ARM platform, making deployment easier on devices like raspberry pi or ARM cloud servers, without requiring the user to build the image on their own. I have tested it on the forked repository with my GHCR credentials and it works properly, I'm also able to run a container properly from the built GHCR hosted arm package. It should work properly with existing secrets defined on the repository. (#87)