### PR TITLE
config: alterable configuration file path by env `CONFIG_PATH`

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ You can configure your config using one of the following methods:
      cp default.config.json5 config.json5
      ```
    - Open `config.json5` and update it with your application's configuration settings.
+   - Set environment variable `CONFIG_PATH` to alter the configuration file path (default to `./config.json5`).
 
 **3. Building and Running with Docker Compose**
 

--- a/index.js
+++ b/index.js
@@ -16,19 +16,20 @@ const Date = require("./object/date.js");
 const Error = require("./object/error.js");
 const RegionalTaskManager = require("./object/regional-task-manager.js");
 
+const configPath = process.env.CONFIG_PATH || "./config.json5";
 let config;
 try {
-	config = JSON5.parse(file.readFileSync("./config.json5"));
+	config = JSON5.parse(file.readFileSync(configPath));
 }
 catch (e) {
-	if (file.existsSync("./config.json5") === false) {
+	if (file.existsSync(configPath) === false) {
 		throw new Error({
-			message: `No config file (config.json5) was found. Please follow the setup instructions on https://github.com/torikushiii/hoyolab-auto?tab=readme-ov-file#installation \n${e}`
+			message: `No config file (${configPath}) was found. Please follow the setup instructions on https://github.com/torikushiii/hoyolab-auto?tab=readme-ov-file#installation \n${e}`
 		});
 	}
 
 	throw new Error({
-		message: `An error occurred when reading your configuration file. Please check and fix the following error:\n${e}`
+		message: `An error occurred when reading your configuration file (${configPath}). Please check and fix the following error:\n${e}`
 	});
 }
 


### PR DESCRIPTION
Extract configuration file path from environment variable `CONFIG_PATH` in `index.js`.
If the env not present, fallback to default `./config.json5`.

This change does NOT break existing installations, but is quite useful for docker compose users like me to mount configuration file under another directory other than `/app`. 