### PR TITLE
fix: another config loader

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,0 +1,21 @@
+const file = require("node:fs");
+const JSON5 = require("json5");
+
+const configPath = process.env.CONFIG_PATH || "./config.json5";
+let config;
+try {
+	config = JSON5.parse(file.readFileSync(configPath));
+}
+catch (e) {
+	if (file.existsSync(configPath) === false) {
+		throw new Error({
+			message: `No config file (${configPath}) was found. Please follow the setup instructions on https://github.com/torikushiii/hoyolab-auto?tab=readme-ov-file#installation \n${e}`
+		});
+	}
+
+	throw new Error({
+		message: `An error occurred when reading your configuration file (${configPath}). Please check and fix the following error:\n${e}`
+	});
+}
+
+module.exports = config;

--- a/crons/index.js
+++ b/crons/index.js
@@ -15,13 +15,7 @@ const Stamina = require("./stamina/index.js");
 const UpdateCookie = require("./update-cookie/index.js");
 const WeekliesReminder = require("./weeklies-reminder/index.js");
 
-let config;
-try {
-	config = JSON5.parse(file.readFileSync("./config.json5"));
-}
-catch {
-	config = JSON5.parse(file.readFileSync("./default.config.json5"));
-}
+const config = require("../config.js");
 
 const definitions = [
 	CheckIn,

--- a/crons/index.js
+++ b/crons/index.js
@@ -1,8 +1,5 @@
 const { CronJob } = require("cron");
 
-const JSON5 = require("json5");
-const file = require("node:fs");
-
 const CheckIn = require("./check-in/index.js");
 const CodeRedeem = require("./code-redeem/index.js");
 const DailiesReminder = require("./dailies-reminder/index.js");

--- a/index.js
+++ b/index.js
@@ -1,6 +1,3 @@
-const file = require("node:fs");
-const JSON5 = require("json5");
-
 const Command = require("./classes/command.js");
 const Config = require("./classes/config.js");
 const Got = require("./classes/got.js");
@@ -16,22 +13,7 @@ const Date = require("./object/date.js");
 const Error = require("./object/error.js");
 const RegionalTaskManager = require("./object/regional-task-manager.js");
 
-const configPath = process.env.CONFIG_PATH || "./config.json5";
-let config;
-try {
-	config = JSON5.parse(file.readFileSync(configPath));
-}
-catch (e) {
-	if (file.existsSync(configPath) === false) {
-		throw new Error({
-			message: `No config file (${configPath}) was found. Please follow the setup instructions on https://github.com/torikushiii/hoyolab-auto?tab=readme-ov-file#installation \n${e}`
-		});
-	}
-
-	throw new Error({
-		message: `An error occurred when reading your configuration file (${configPath}). Please check and fix the following error:\n${e}`
-	});
-}
+const config = require("./config.js");
 
 (async () => {
 	const start = process.hrtime.bigint();


### PR DESCRIPTION
Sorry to bother again. After my previous pr #97, I found a new problem there.
There is still a hard-coded configuration file path in `crons/index.js`, which even default to `./default.config.json5` if `./config.json5` does not exist.

Now I've moved `config` to a new `config.js` file, and `require` it back in both `index.js` and `crons/index.js`.