### PR TITLE
Invalid cron expressions fix

### DIFF
--- a/default.config.json5
+++ b/default.config.json5
@@ -28,13 +28,13 @@
         whitelist: [], // You can whitelist some crons if you only want to run specific crons
         blacklist: [], // You can blacklist some crons if you don't want to run them
         // You can use this site to generate cron expression: https://crontab.guru/
-        checkIn: '0 0 0 * * *',
-        codeRedeem: '*/15 * * * *',
-        expedition: '0 */30 * * * *',
-        missedCheckIn: '0 0 23 * * *',
-        realmCurrency: '0 */1 * * *',
-        shopStatus: '0 */1 * * *',
-        stamina: '0 */30 * * * *'
+        checkIn: '0 * * * *',
+        missedCheckIn: '0 * * * *',
+        codeRedeem: '0 * * * *',
+        expedition: '*/30 * * * *',
+        realmCurrency: '*/30 * * * *',
+        shopStatus: '0 * * * *',
+        stamina: '*/30 * * * *'
     },
     accounts: [
         {


### PR DESCRIPTION
Fixed invalid cron expressions "0 */30 * * * *" to "*/30 * * * *" and changed "0 */1 * * *" to equivalent "0 * * * *"

Proposing new default values for cron jobs (hourly check in seems safer in case of network/hardware/user failure).