### PR TITLE
Fix object serialization in warn logs

### DIFF
--- a/singleton/logger.js
+++ b/singleton/logger.js
@@ -95,7 +95,8 @@ class Logger {
 	}
 
 	warn (type, text) {
-		this.winstonLogger.warn(this.formatMessage(type, text));
+		const target = (typeof text === "object") ? util.inspect(text) : text;
+		this.winstonLogger.warn(this.formatMessage(type, target));
 	}
 
 	debug (type, text) {


### PR DESCRIPTION
There was a warning uncaptured during Mimo automation during season transition.
`2026-03-24 06:00:00 <[33mWARN[39m:Cron:Mimo> [object Object]`
This fix resolves that.