### PR TITLE
Credit Mimo lottery point rewards

### DIFF
--- a/hoyolab-modules/mimo.js
+++ b/hoyolab-modules/mimo.js
@@ -517,6 +517,10 @@ module.exports = class TravelingMimo {
 						code: drawResult.data.code
 					});
 					results.points -= cost;
+					const pointsReward = drawResult.data.name?.match(/^Points x(\d+)$/);
+					if (pointsReward) {
+						results.points += Number(pointsReward[1]);
+					}
 					drawsRemaining--;
 
 					app.Logger.info(`${this.#instance.fullName}:Mimo`, `(${accountData.uid}) Lottery draw: ${drawResult.data.name}`);


### PR DESCRIPTION
When the lottery successfully earns Points, the `result.points` isn't updated to reflect this, so the lottery ends prematurely.

This fix adds the points earned to the `result.points` within the loop, to allow it the chance to keep drawing.